### PR TITLE
Update help-ja.asc

### DIFF
--- a/help-ja.asc
+++ b/help-ja.asc
@@ -14,9 +14,7 @@
 
 AnkiDroidに限定されない問題に関するお問い合わせ :: AnkiDroid（AnkiのAndroidアプリ版）は、Ankiの作者 Damien Elmes 氏 が管理する他のバージョンのAnkiと異なり、有志グループによって独自に開発・管理されています。PCソフトAnki、Web版Anki（AnkiWeb）、iOSアプリ版Anki（AnkiMobile）等に関する問題や、AnkiDroidに限らずAnki全体に共通する問題については、「本家」であるAnkiの https://anki.tenderapp.com/[サポートページ] （英語）にお問い合わせください。
 
-AnkiDroidに関するお問い合わせ :: AnkiDroidに関するお問い合わせは、 https://groups.google.com/forum/\#!forum/ankidroid-nihon[ユーザーフォーラム（日本語用）]に投稿するか、このフォーラムのmailto:ankidroid-nihon@googlegroups.com[アドレス]にメールしてください。
-
- 訳注：お問い合わせを英語で行う場合は、こちらの https://groups.google.com/forum/#!forum/anki-android[ユーザーフォーラム]に投稿するか、このフォーラムのmailto:public-forum@ankidroid.org[アドレス]にメールしてください。）
+AnkiDroidに関するお問い合わせ :: AnkiDroidに関するお問い合わせは、 https://groups.google.com/forum/\#!forum/ankidroid-nihon[ユーザーフォーラム（日本語用）]に投稿するか、このフォーラムのmailto:ankidroid-nihon@googlegroups.com[アドレス]にメールしてください。（訳注：お問い合わせを英語で行う場合は、こちらの https://groups.google.com/forum/#!forum/anki-android[ユーザーフォーラム]に投稿するか、このフォーラムのmailto:public-forum@ankidroid.org[アドレス]にメールしてください。）
 
 バグレポートや新機能リクエスト :: バグ（不具合）の報告や新機能のリクエストを送りたい場合は、まず https://github.com/ankidroid/Anki-Android/issues[AnkiDroidイシュートラッカー]（英語）に公開されているイシュー（課題）リストに同じ内容がないかどうか確認してみてください。
 ない場合は、新しいイシューを作成し、できるだけ詳しい情報を記載してください。
@@ -37,6 +35,4 @@ https://github.com/ankidroid/Anki-Android/issues[AnkiDroidイシュートラッ�
 この「デバッグ情報」は重要です。これがあると、サポートチームはあなたが書いたバグレポートとあなたのAnkiDroidが送信したクラッシュレポートとを照らし合わせることができます。
 
 == AnkiDroidへの貢献
-AnkiDroidはオープンソースプロジェクトです。このアプリの発展に貢献したいという方であればどなたでも（アプリ開発者でない方も）歓迎いたします。AnkiDroidへの貢献に関心を持たれた方は、最初にAnkiDroid公式サイトの https://github.com/ankidroid/Anki-Android/wiki/Contributing[“Contribution”]（貢献）のページ（英語）をご覧の上、 https://groups.google.com/forum/#!forum/ankidroid-nihon[ユーザーフォーラム（日本語用）]にお問い合わせください。
-
- 訳注：お問い合わせを英語で行う場合は、こちらの https://groups.google.com/forum/#!forum/anki-android[ユーザーフォーラム]にお問い合わせください。
+AnkiDroidはオープンソースプロジェクトです。このアプリの発展に貢献したいという方であればどなたでも（アプリ開発者でない方も）歓迎いたします。AnkiDroidへの貢献に関心を持たれた方は、最初にAnkiDroid公式サイトの https://github.com/ankidroid/Anki-Android/wiki/Contributing[“Contribution”]（貢献）のページ（英語）をご覧の上、 https://groups.google.com/forum/#!forum/ankidroid-nihon[ユーザーフォーラム（日本語用）]にお問い合わせください。（訳注：お問い合わせを英語で行う場合は、こちらの https://groups.google.com/forum/#!forum/anki-android[ユーザーフォーラム]にお問い合わせください。）


### PR DESCRIPTION
Revert to the previous style of the annotation for Japanese, since its links won't work on the new style.