### PR TITLE
Information about <tts> tags plus some indentation corrections

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -581,6 +581,7 @@ Fetch media on sync:: By default, AnkiDroid will sync sounds and images as well 
 
 Automatic synchronization:: Enable this option if you want AnkiDroid to sync every time you open and close the app. There is a limit of once every ten minutes for this behavior. Once a sync begins you can cancel it by pressing your device's back button, however it can take some time for the cancellation to take effect.
 
++
 Users that want more fine-grained control over when sync occurred might like to use a 3rd party app like Tasker to automate synchronization. See the https://github.com/ankidroid/Anki-Android/wiki/AnkiDroid-API#sync-intent[API documentation] for more information on this.
  
 Deck for new cards:: The default of "Use current deck" means that Anki saves the last-used note type for each deck 
@@ -633,6 +634,7 @@ Keep screen on :: Ignore the automatic screen timeout setting in Android to alwa
 
 Fullscreen mode :: Switches to an immersive fullscreen mode so that you can use more of the screen. You can choose between "Hide the system bars" which will hide the system status bar, action bar, and bottom navigation buttons. Alternatively you can choose "Hide the system bars and answer buttons", which will hide everything except for the actual card content itself. You can temporarily exit fullscreen mode by swiping inwards (i.e. down or up) from the system bars.
 
++
 Note that immersive fullscreen mode is only supported on Android 4.4+
 
 Center align ::  By default AnkiDroid tries to show cards exactly as they are shown on Anki Desktop, however if you prefer your cards 
@@ -758,9 +760,12 @@ Take into account the effect of future reviews in the 'Forecast' graph. More inf
 Type answer into the card ::
 If you have set up your cards to ask you to type in the answer (as explained in http://ankisrs.net/docs/manual.html#templates[this section of the desktop manual]), AnkiDroid will display a keyboard on such cards and allow you to check your answer.
 
++
+--
 In order to improve user experience when working with the whiteboard and gestures, we use a typing box separate from the card, which is inconsistent with the way the feature works on Anki Desktop.
 
 For full consistency with Anki Desktop, you can enable this option which allows you to save screen area, and choose an appropriate font (e.g. Japanese vs Chinese) for the input box.
+--
 
 Input Workaround ::
 Some older devices couldn't gain focus into the text input box for typed-answer fields, so this was added (Hidden for API > 14).
@@ -807,13 +812,15 @@ To make both AnkiDroid and the https://ankiatts.appspot.com/[AwesomeTTS] plugin 
 ....
 
 AnkiDroid automatically ignores `<tts>` tags selecting an unknown TTS service. In contrast, AwesomeTTS may display a warning message on encountering the `<tts service="android" ...>` tag; to suppress it, uncheck the two _Show errors_ checkboxes on the _Playback_ tab of the _AwesomeTTS: Configuration_ dialog in the desktop application.
---
 
 _This feature may be removed in the future in favor of a separately downloadable plugin_
+--
 
 Lookup Dictionary ::
 Dictionary to use to lookup words copied to the clipboard in the reviewer. After setting up a dictionary, do the following to perform the lookup:
 
++
+--
  * Longclick on the text you want to copy in the reviewer
  * After selecting the word you want to copy, press the "copy" icon in the action bar at the top of the screen
  * Tap once anywhere on the flashcard
@@ -822,6 +829,7 @@ Dictionary to use to lookup words copied to the clipboard in the reviewer. After
 Alternatively, the lookup action can be performed via a gesture.
 
 _This feature will likely be removed in the future in favor of a plugin_
+--
 
 Reset Languages ::
 Useful for resetting the TTS language
@@ -829,6 +837,7 @@ Useful for resetting the TTS language
 eReader (up/down buttons) ::
 Support for eReader hardware buttons (see https://github.com/ankidroid/Anki-Android/issues/1625[issue 1625])
 
++
 _This feature will likely be removed in the future in favor of a plugin_
 
 eReader Double Scrolling ::
@@ -942,6 +951,7 @@ If this setting is set to a number greater than 0, instead of randomly choosing 
 One review has a couple of possible outcomes (say 4), which all result in a review. That review also has a couple of possible outcomes and so on. If many reviews are simulated this way, many reviews (4 x 4 x 4 x ... ) have to be taken into account which increases the time it takes to compose the graph.
 Therefore, for reviews later than n days from now are simulated by randomly choosing an outcome.
 
++
 In summary, higher n gives a more accurate graph, but it takes more time to compose the graph.
 
 Precision of computation ::
@@ -949,6 +959,7 @@ Precision of computation ::
 Reviews which occur with a probability smaller than 100% minus the configured precision of the computation are simulated by randomly choosing an outcome rather than taking into account each possible outcome. This setting is only applicable if the first n days are computed. 
 If Advanced Statistics are disabled, the 'Forecast' graph shows the estimated number of reviews that will be due on a given day in the future if you do not review cards, learn no new cards and fail no cards.
 
++
 In summary, higher precision gives a more accurate graph, but it takes more time to compose the graph.
 
 Number of iterations of  the simulation ::
@@ -957,6 +968,7 @@ Each time the graph is composed, another outcome might be randomly chosen.  If w
 If we average many graphs, the average graph will likely be close to the graph which is generated by taking into account all possible outcomes.
 If the number of graphs which are averaged is not too high, it will be faster than taking into account all possible outcomes.
 
++
 In summary, a higher number of iterations gives a more accurate graph, but it takes more time to compose the graph.
 
 [[reminders]]

--- a/manual.asc
+++ b/manual.asc
@@ -776,6 +776,39 @@ Enable this option to have Android read out all the text on your flashcards usin
 AnkiDroid will ask you to select the language for the front and back of your cards once for each deck on the first time you review a card in that deck. 
 To change the language or disable TTS for a given deck after making your initial choice, you'll need to use the "reset languages" option described below and reconfigure for each deck.
 
++
+--
+Alternatively, if you want only fragments of cards to be read aloud, or if you want to set the TTS language for multiple decks at once, you can insert `<tts>` tags into <<customizingCardLayout, card templates>>. For example, with the following template for the back of the card
+
+[subs=+quotes]
+....
+{{FrontSide}}
+
+<hr id=answer>
+
+*<tts service="android" voice="en_GB">*{{EnglishTranslation}}**</tts>**
+<br><br>
+{{Example}}
+....
+
+only the `EnglishTranslation` field will be read aloud in a British English voice; the `Example` field, lying outside the `<tts>` tag, won't be read aloud. Every `<tts>` tag needs to have the following two attributes:
+
+ * `service`: should be set to `"android"`, otherwise the contents of the `<tts>` tag won't be read aloud;
+ * `voice`: used to select the TTS language; should be a https://en.wikipedia.org/wiki/List_of_ISO_639-2_codes[two- or three- letter language code], optionally followed by an underscore and a https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2[two-letter country or region code]. A frequently updated list of languages supported by the Google TTS engine can be found on its https://en.wikipedia.org/wiki/Google_Text-to-Speech[Wikipedia page].
+
+To make both AnkiDroid and the https://ankiatts.appspot.com/[AwesomeTTS] plugin to the desktop application use a TTS engine to read aloud certain card fragments, put the `<tts service="android" ...>` tag inside the `<tts>` tag recognised by AwesomeTTS, or vice versa. An example:
+
+....
+<tts service="sapi5js" quality="39" speed="0" voice="Microsoft David Desktop" volume="100" xml="0">
+    <tts service="android" voice="en_GB">
+        {{EnglishTranslation}}
+    </tts>
+</tts>
+....
+
+AnkiDroid automatically ignores `<tts>` tags selecting an unknown TTS service. In contrast, AwesomeTTS may display a warning message on encountering the `<tts service="android" ...>` tag; to suppress it, uncheck the two _Show errors_ checkboxes on the _Playback_ tab of the _AwesomeTTS: Configuration_ dialog in the desktop application.
+--
+
 _This feature may be removed in the future in favor of a separately downloadable plugin_
 
 Lookup Dictionary ::


### PR DESCRIPTION
The first commit extends the manual with information about `<tts>` tags (see ankidroid/Anki-Android#1463 and ankidroid/Anki-Android#4677). The second corrects the indentation of the second, third etc. paragraphs of some items in labelled lists (I hope this isn't a controversial change, but please let me know if you'd prefer this commit to be moved to a separate pull request or removed altogether).