### PR TITLE
Add concrete info about beta/alpha, 2.8.5beta1 non-release

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -2,7 +2,8 @@
 :sectanchors:
 = AnkiDroid Changelog
 
-== Version 2.8.5 (2018-10-12)
+== Version 2.8.5beta1 (2018-10-12)
+* Note: 2.8.5 will never be released, due to Google targetSdkVersion restrictions
 * Fix crash and database corruption when discarding card template edits
 * Fix widget crash on older devices (pre-Ice Cream Sandwich, Android 4.0.3)
 * Fix excessive pull-to-sync false positives. Disable when not at top of page.

--- a/manual.asc
+++ b/manual.asc
@@ -937,18 +937,24 @@ To stop receiving notifications go to Deck options > Reminders and unmark the ch
 
 [[betaTesting]]
 === Beta testing
-If you want to try out the latest features in AnkiDroid, you can sign up for the beta testing program as follows:
+
+Beta releases :: If you want to try out the latest features in AnkiDroid, you can sign up for the beta testing program as follows:
 
  . Visit the https://play.google.com/apps/testing/com.ichi2.anki[Google Play Beta page]
  . Click *Become a beta tester*
  
-After following these steps, the latest beta version will automatically be installed by Google Play in the same way as ordinary updates.
-If you are more adventurous, you can also become an alpha tester, by joining the https://groups.google.com/forum/#!forum/ankidroidalphatesters[alpha testers group]
-in addition to performing the above steps for beta testing.
+Alpha releases :: If you are more adventurous, you can also become an alpha tester, by joining the https://groups.google.com/forum/#!forum/ankidroidalphatesters[alpha testers group]
+in addition to performing the above steps for beta testing. The group itself receives no messages, it is used exclusively to determine which Google accounts Google Play will deliver alpha releases to.
 
-Please submit any bugs you find in these development versions to the AnkiDroid issue tracker, as per the link:help.html[main help page].
+Beta / alpha / stable release compatibility :: The 2.8.x releases and the 2.9.x releases are forwards and backwards compatible, with no known risk of data loss. It should be safe to try a 2.9.x alpha or beta while preserving the ability to leave the program and use 2.8.x on the same collection.
 
-If you wish to leave the testing program at any time, simply visit the https://play.google.com/apps/testing/com.ichi2.anki[Google Play Beta page] and click *Leave the test*
+Release delivery :: After following these steps, Google Play will automatically deliver the most recent available beta (or alpha) release to your device in the same way as ordinary updates, after some delay. +
++
+To get a beta or alpha update with no delay instead of waiting, may manually tap the button to scan for updates in the Google Play Store app on your device, then update via the update button in the list of app updates found (not in the app details section).
+
+Test release issue reporting :: Please submit any bugs you find in these development versions to the AnkiDroid issue tracker, as per the link:help.html[main help page].
+
+Returning to stable releases :: If you wish to leave the testing program at any time, simply visit the https://play.google.com/apps/testing/com.ichi2.anki[Google Play Beta page] and click *Leave the test*
 
 [[contributing]]
 == Contributing to AnkiDroid


### PR DESCRIPTION
@timrae I find myself referring to https://docs.ankidroid.org/manual.html#betaTesting all the time but with the same added info about compatibility etc and alpha testing information. I'd like to have this update (or something like it) visible on the link to increase my efficiency on play store and google group responses