### PR TITLE
Included .anki2 Import Instructions

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -513,6 +513,21 @@ You can also manually import .apkg files as follows:
  * Choose the apkg file you just copied to your device when prompted
  * Tap OK
  
+== Importing Anki Databases (.anki2)
+ 
+AnkiDroid does not yet support directly importing Anki database (`.anki2`) files. A database import will replace your collection with the contents the provided file. If you want to perform a full replacement, you should ideally import an exported `collection[.apkg/.colpkg]`, as this also includes media data.
+ 
+=== Importing anki2 files manually
+
+`.anki2` files can manually be imported:
+
+* Create a new folder on your Android file system
+* Obtain the full path to the folder as provided by your file manager, this will typically appear as: `/storage/emulated/0/<FolderName>`
+* Place the `.anki2` file in the newly created folder
+* Rename the file to `collection.anki2`
+* (If applicable) Temporarily log out of your AnkiWeb account: `Settings - AnkiDroid - AnkiWeb account`
+* Open `Settings - Advanced - AnkiDroid Directory` and set the AnkiDroid Directory to the newly created folder.
+
 [[exporting]]
 == Exporting Anki Files
 AnkiDroid can export your flashcards in the .apkg Anki file format so that you can import them into Anki Desktop, or share them with other people. 

--- a/manual.asc
+++ b/manual.asc
@@ -519,7 +519,7 @@ AnkiDroid does not support directly importing Anki database (`.anki2`) files. A 
  
 === Importing anki2 files manually
 
-`.anki2` files can manually be imported:
+This is not officially supported, but `.anki2` files can manually be imported if needed, in cases of troubleshooting for example:
 
 * Create a new folder on your Android file system
 * Obtain the full path to the folder as provided by your file manager, this will typically appear as: `/storage/emulated/0/<FolderName>`

--- a/manual.asc
+++ b/manual.asc
@@ -515,7 +515,7 @@ You can also manually import .apkg files as follows:
  
 == Importing Anki Databases (.anki2)
  
-AnkiDroid does not yet support directly importing Anki database (`.anki2`) files. A database import will replace your collection with the contents the provided file. If you want to perform a full replacement, you should ideally import an exported `collection[.apkg/.colpkg]`, as this also includes media data.
+AnkiDroid does not support directly importing Anki database (`.anki2`) files. A database import will replace your collection with the contents the provided file. If you want to perform a full replacement, you should import a `collection[.apkg/.colpkg]` created in the app with the export function.
  
 === Importing anki2 files manually
 


### PR DESCRIPTION
I assume a lot of our import errors are due to anki2 imports failing.

We can direct users here to find a better solution or cut down on support work.

Related: https://github.com/ankidroid/Anki-Android/pull/6258
