### PR TITLE
Fix Mark Note Shortcut (*)

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -1096,7 +1096,7 @@ Notifications only work for top level decks. Please let us know if you want us t
 |kbd:[e]
 |Edit Note
 
-|kbd:[\*]
+|kbd:[*]
 |Mark Note
 
 |kbd:[-]


### PR DESCRIPTION
Was displaying as `\*`

Now: 
![image](https://user-images.githubusercontent.com/62114487/103180923-be4bdd00-4892-11eb-9904-3ebc495949e4.png)

Tested on CI for my repo