### PR TITLE
Rename "Action bar" to "App bar"

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -56,9 +56,9 @@ Create deck :: Create a new empty deck
  . Choose a name for the deck, for example "New Japanese"
  . Add cards to it following the "Add" instructions above
 
-=== Action Bar
-At the top of each screen in AnkiDroid is the Action Bar, with buttons for performing various actions. 
-The following actions are available from the action bar in the deck list:
+=== App Bar
+At the top of each screen in AnkiDroid is the App Bar, with buttons for performing various actions. 
+The following actions are available from the app bar in the deck list:
 
 Navigation menu button :: Tapping the icon on the far left will show the <<drawer,left navigation menu>> for quickly navigating between the main parts of the app.
 
@@ -67,7 +67,7 @@ Sync button :: The circular button with arrows on the right is for synchronizing
 
 Overflow menu button :: On the far right is the overflow menu which contains less commonly used actions. These actions are described further below.
 
-**Hint:** long tapping on a button in the action bar anywhere in the app will display a textual hint describing what the 
+**Hint:** long tapping on a button in the app bar anywhere in the app will display a textual hint describing what the 
 button does!
 
 === Studying a Deck
@@ -163,8 +163,8 @@ From the deck list, if you tap the counts area you will be taken to the deck ove
 
 On this screen you can view a summary of the deck, build custom study sessions, rebuild / empty filtered decks, and change deck options. When visible, pressing the study button will take you to the study screen for that deck.
 
-=== Action bar
-The icons that are shown in the action bar depend on whether your deck is an ordinary deck or a filtered deck.
+=== App bar
+The icons that are shown in the app bar depend on whether your deck is an ordinary deck or a filtered deck.
 
 ==== Ordinary decks
 
@@ -211,8 +211,8 @@ the time a card will next be shown, so 10m means "10 minutes" and "5d" means
 To make reviewing faster, you can configure gestures (for example taps and swipes) to answer cards without using the buttons. 
 See the <<settings, preferences section>> for more information on configuring gestures.
 
-=== Action Bar
-The Action Bar at the top of the study screen has several buttons for performing various common actions. The number of buttons which are shown 
+=== App Bar
+The App Bar at the top of the study screen has several buttons for performing various common actions. The number of buttons which are shown 
 is determined automatically by Android based on the size and resolution of your screen. If there is not enough space to show the button 
 for a given action, then the action will be available from the menu instead. If you are unsure what a button does, you can long-tap on it to 
 see the name of the action. The following action are available:
@@ -276,7 +276,7 @@ the source code for the card template of the selected note type.  From here you 
 
 Long press in a text entry field to add a cloze deletion around the selected text, or an empty cloze deletion if there is no selected text.
 
-When you've finished typing in the content of a note, tap the tick icon in the action bar at the top to add it to
+When you've finished typing in the content of a note, tap the tick icon in the app bar at the top to add it to
 your collection. Alternatively, if you want to go back to what you were doing without saving, you can tap the app icon, or 
 use the hardware back button.
 
@@ -416,7 +416,7 @@ In this scenario you have some existing Anki decks that you want to copy into a 
 If you have never used AnkiWeb before you will need to enter your credentials if prompted, and 
 then press the "Upload to AnkiWeb" button to confirm overwriting the empty collection on AnkiWeb with your existing decks in Anki. Anki will upload all your cards, images and audio to AnkiWeb. If you have a lot of media, this may take some time.
 
-Once the synchronization has completed, open AnkiDroid in the device that you are trying to copy the existing decks into, and tap the *Sync* button in the action bar at the top of the main <<deckPicker, deck list>>. 
+Once the synchronization has completed, open AnkiDroid in the device that you are trying to copy the existing decks into, and tap the *Sync* button in the app bar at the top of the main <<deckPicker, deck list>>. 
 After entering your AnkiWeb credentials, AnkiDroid will download all your cards and media, and remember your login information for next time.
 
 Note that if you have any existing material in AnkiDroid before attempting to sync, you may be shown a message 
@@ -879,7 +879,7 @@ Dictionary to use to lookup words copied to the clipboard in the reviewer. After
 +
 --
  * Longclick on the text you want to copy in the reviewer
- * After selecting the word you want to copy, press the "copy" icon in the action bar at the top of the screen
+ * After selecting the word you want to copy, press the "copy" icon in the app bar at the top of the screen
  * Tap once anywhere on the flashcard
  * A magnifying glass icon should appear, which performs the lookup when clicked
 


### PR DESCRIPTION
What is been changed ?
- "Action Bar" word is changed to "App Bar" as this issue is mentioned in issue no ankidroid#28 of ankidroiddocs.
- Naming convention in Material UI is also changed from Action Bar to App Bar.