### PR TITLE
docs(manual): Quick fix for set language hint feature

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -1054,9 +1054,9 @@ Notifications only work for top level decks. Please let us know if you want us t
 
 [[setlanguagehint]]
 === Automatic Language Selection
-AnkiDroid will help you in Automatic Language Selection feature from AnkiDroid 2.13. This feature allows you to define a default language for a field in a note type.
+AnkiDroid has an in Automatic Language Selection feature in the Note Editor starting with AnkiDroid 2.13. This feature allows you to define a default language to be used in your keyboard for a field in a note type.
 
-For e.g. You have Russian and English translation fields. So, the layout (in the apps SwiftKey and Swype as most popular, for example) switches to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
+For example, if you have Russian and English note fields, the keyboard layout (in keyboards like SwiftKey and Swype) will switch to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
 
 
 [[keyboardShortcuts]]

--- a/manual.asc
+++ b/manual.asc
@@ -1056,7 +1056,7 @@ Notifications only work for top level decks. Please let us know if you want us t
 === Automatic Language Selection
 AnkiDroid has an in Automatic Language Selection feature in the Note Editor starting with AnkiDroid 2.13. This feature allows you to define a default language to be used in your keyboard for a field in a note type.
 
-For example, if you have Russian and English note fields, the keyboard layout (in keyboards like SwiftKey and Swype) will switch to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
+For example, if you have Russian and English note fields, the keyboard layout (need to support the setImeHintLocales Android API) will switch to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
 
 
 [[keyboardShortcuts]]

--- a/manual.asc
+++ b/manual.asc
@@ -1052,6 +1052,13 @@ To stop receiving notifications go to Deck options > Reminders and unmark the ch
 
 Notifications only work for top level decks. Please let us know if you want us to add notifications for subdecks too.
 
+[[setlanguagehint]]
+=== Automatic Language Selection
+AnkiDroid will help you in Automatic Language Selection feature from AnkiDroid 2.13. This feature allows you to define a default language for a field in a note type.
+
+For e.g. You have Russian and English translation fields. So, the layout (in the apps SwiftKey and Swype as most popular, for example) switches to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
+
+
 [[keyboardShortcuts]]
 == Keyboard Shortcuts
 

--- a/manual.asc
+++ b/manual.asc
@@ -1057,7 +1057,7 @@ Notifications only work for top level decks. Please let us know if you want us t
 AnkiDroid has an in Automatic Language Selection feature in the Note Editor starting with AnkiDroid 2.13. This feature allows you to define a default language to be used in your keyboard for a field in a note type.
 
 
-For example, if you have Russian and English note fields, the keyboard layout (need to support the setImeHintLocales Android API) will switch to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
+For example, if you have Russian and English note fields, and your keyboard supports the setImeHintLocales Android API, the keyboard layout will switch to Russian in the first field and back to English in the second automatically when the fields get focus. https://youtu.be/JrxDjTrRhBE[Checkout video reference for demonstration]
 
 [[keyboardShortcuts]]
 == Keyboard Shortcuts


### PR DESCRIPTION
- Change the named keyboard apps to they need to support the setImeHintLocales Android API