### PR TITLE
Update Anki Desktop manual addresses

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -13,7 +13,7 @@ http://ankisrs.net/[Anki] spaced repetition system.
 Anki is spaced repetition technique which is simple but highly effective. It helps you memorize things by automatically repeating them across increasing intervals based on your responses with no need for you to keep track of what to study or when to study it. You create notes (or download shared decks) with content you need to memorize, and the scheduler will make sure you see the content when you need to.
 
 AnkiDroid is intended to be used in conjunction with Anki on your computer. While it is possible to function without it, 
-some tasks are either only possible with, or a lot more efficient with Anki Desktop. Furthermore, it is *strongly recommended* to at least read https://docs.ankiweb.net/#/getting-started?id=key-concepts["Key Concepts"] section of the main Anki manual to understand the terminology used here.
+some tasks are either only possible with, or a lot more efficient with Anki Desktop. Furthermore, it is *strongly recommended* to at least read https://docs.ankiweb.net/getting-started.html#key-concepts["Key Concepts"] section of the main Anki manual to understand the terminology used here.
 
 If this manual doesn't contain what you are looking for, please check the https://github.com/ankidroid/Anki-Android/wiki[AnkiDroid Wiki] for a list of changes, instructions for submitting bug reports and feature requests, a list of frequently asked questions, and much more.
 
@@ -28,7 +28,7 @@ you might like to skip straight to the <<AnkiDesktop, using AnkiDroid with Anki 
 
 [[deckPicker]]
 == The Deck List
-*_Note:_* _This section onwards assumes you understand what https://docs.ankiweb.net/#/getting-started?id=key-concepts[decks and cards] are_
+*_Note:_* _This section onwards assumes you understand what https://docs.ankiweb.net/getting-started.html#key-concepts[decks and cards] are_
 
 The deck list is the screen you see when you start AnkiDroid. It displays a 
 list of the decks which contain all of your flashcards, and allows you to perform various actions:
@@ -40,7 +40,7 @@ list of the decks which contain all of your flashcards, and allows you to perfor
 === Add button
 The big blue + button in the bottom right corner is used to add new material to AnkiDroid. Pressing it expands to give the following three options, which are also described in the https://www.youtube.com/watch?v=F2K1gOSdIZA[tutorial video].
 
-Add :: Choose this option if you want to create your own flashcards (notes) with AnkiDroid. "Notes" and "cards" have specific meanings in Anki, which are https://docs.ankiweb.net/#/getting-started?id=key-concepts[explained in the main Anki manual]. Please see the tutorial video for a quick introduction to adding notes, or refer to the <<addingNotes,adding notes>> section below for more detailed information.
+Add :: Choose this option if you want to create your own flashcards (notes) with AnkiDroid. "Notes" and "cards" have specific meanings in Anki, which are https://docs.ankiweb.net/getting-started.html#key-concepts[explained in the main Anki manual]. Please see the tutorial video for a quick introduction to adding notes, or refer to the <<addingNotes,adding notes>> section below for more detailed information.
 
 Get shared decks :: To download a deck of cards from the internet that another user has contributed:
  . Ensure you're connected to the internet.
@@ -83,7 +83,7 @@ Long tapping on a deck will show a list of other actions available to perform on
 Rename deck :: Use this option to rename a deck
 
 Deck options :: Tapping on deck options allows you to configure various deck specific study options.
-Please see the https://docs.ankiweb.net/#/deck-options?id=deck-options[desktop documentation] for more information about these study options.
+Please see the https://docs.ankiweb.net/deck-options.html#deck-options[desktop documentation] for more information about these study options.
 
 Custom study :: Allows you to choose from some convenient presets for studying outside of your normal schedule, for example increasing the study limit for the day. See the section on <<filtered,"filtered decks">> for more detailed information.
 
@@ -100,7 +100,7 @@ Rebuild / Empty :: If the selected deck is a <<filtered,filtered deck>> then you
 Each deck in the list has three clickable areas:
 
 Deck expander :: If you are using 
-https://docs.ankiweb.net/#/getting-started?id=decks[subdecks], then a deck expander button may appear on the far left of the deck, which can be used to show / hide the subdecks. A ▶ icon means the deck has hidden subdecks which can be shown, a ▼ icon means the deck has visible subdecks that can be hidden, and no icon means that the deck has no subdecks. Note: subdecks can be created by using the naming convention "PARENT::CHILD".
+https://docs.ankiweb.net/getting-started.html#decks[subdecks], then a deck expander button may appear on the far left of the deck, which can be used to show / hide the subdecks. A ▶ icon means the deck has hidden subdecks which can be shown, a ▼ icon means the deck has visible subdecks that can be hidden, and no icon means that the deck has no subdecks. Note: subdecks can be created by using the naming convention "PARENT::CHILD".
 
 Deck name :: This is the main clickable area, which will take you to the study screen if there are cards available to review.
 
@@ -117,7 +117,7 @@ NOTE: Under some circumstances, check database will move cards to a deck named _
 
 Check media :: Try to run this if you experience any issues with media syncing.
 
-Empty cards :: Remove any empty cards from your collection. See the https://docs.ankiweb.net/#/templates/generation?id=card-generation-amp-deletion[desktop documentation] for more.
+Empty cards :: Remove any empty cards from your collection. See the https://docs.ankiweb.net/templates/generation.html#card-generation-amp-deletion[desktop documentation] for more.
 
 Restore from backup :: Allows you to restore from one of AnkiDroid's <<backups,automatic backups>>
 
@@ -150,7 +150,7 @@ for quickly navigating between different parts of the application. You can switc
 
 Decks :: Takes you to the top level of the app where the list of cards are shown (<<deckPicker,more info here>>)
 Card Browser :: Shows a list of all your cards (<<browser,more info here>>)
-Statistics :: Helps you track your study progress (https://docs.ankiweb.net/#/stats?id=statistics[more info in Anki manual] and <<advancedStatistics,here>>)
+Statistics :: Helps you track your study progress (https://docs.ankiweb.net/stats.html#statistics[more info in Anki manual] and <<advancedStatistics,here>>)
 Night mode :: This switches the app to a dark theme which many users find is less straining on the eyes, particularly when reviewing in the dark. See the https://github.com/ankidroid/Anki-Android/wiki/Advanced-formatting#customize-night-mode-colors[wiki] for instructions on how to customize the card background and font color used in night mode.
 Settings :: Allows you to customize the app (<<settings,more info here>>)
 Help :: Opens this web page
@@ -182,7 +182,7 @@ Rebuild deck :: Tapping the rebuild icon will rebuild the current filtered deck 
 
 Deck Options :: Allows you to configure some options related to the current 
 deck, such as the number of new cards and reviews to introduce each day.
-Please see the https://docs.ankiweb.net/#/deck-options?id=deck-options[desktop documentation] for more information about these study options.
+Please see the https://docs.ankiweb.net/deck-options.html#deck-options[desktop documentation] for more information about these study options.
 
 Unbury :: This option is only visble when the selected deck has cards that have been manually or automatically buried.
 
@@ -195,13 +195,13 @@ Tapping on the deck name from the deck list, or the study button from the deck o
 
 === Basics
 If you have not used Anki on a computer before, you may like to have a look at the
-first https://docs.ankiweb.net/#/getting-started?id=videos[intro video]
+first https://docs.ankiweb.net/getting-started.html#videos[intro video]
 before reading on, as it explains the basic review process.
 
 On the top left of the screen you'll see three numbers. From the left, these
 correspond to new cards, learning cards, and cards to review. These are
 explained in more detail in the intro videos for the desktop program, so
-please https://docs.ankiweb.net/#/getting-started?id=videos[check them out]
+please https://docs.ankiweb.net/getting-started.html#videos[check them out]
 if you haven't already.
 
 When you've looked at a card's question and remembered the answer, or decided
@@ -235,7 +235,7 @@ Replay Audio :: If the card has audio on the front or back, it will be played ag
 Enable / Disable Whiteboard :: This action enables or disables the whiteboard feature for the current deck. The whiteboard feature allows you to draw on the screen, 
 which is particularly useful for practicing drawing characters from languages such as Japanese. When the whiteboard has been enabled for the current deck, 
 two new actions will become available for clearing and hiding the whiteboard. Disabling the whiteboard will hide these actions as well as the whiteboard itself.
-Deck options :: Open the deck specific study options. See the https://docs.ankiweb.net/#/deck-options?id=deck-options[desktop documentation] for more information about these study options.
+Deck options :: Open the deck specific study options. See the https://docs.ankiweb.net/deck-options.html#deck-options[desktop documentation] for more information about these study options.
 Check Pronunciation :: This action enables or disables the temporary audio recorder toolbar at the top of the card. This feature allows you to record your voice and replay it. It is used primarily to check your pronunciation. This toolbar is composed of three buttons: play, stop playing and record microphone audio. This tool can be used while viewing either the question or the answer.
 
 === Reaching the end of the study session
@@ -248,7 +248,7 @@ If you wish to keep studying the same deck further, tap on the deck again which 
 
 [[addingNotes]]
 == Add Note Screen
-*_Note:_* _This section onwards assumes you understand what https://docs.ankiweb.net/#/getting-started?id=notes-amp-fields[notes, fields, card templates, and note types] are_
+*_Note:_* _This section onwards assumes you understand what https://docs.ankiweb.net/getting-started.html#notes-amp-fields[notes, fields, card templates, and note types] are_
 
 To add a new note, tap the + button at the bottom of the deck list and choose "Add".
 ++++++++++
@@ -274,7 +274,7 @@ search for translations or pronunciation audio files online.
 Tags :: Brings up a dialog which lets you add / remove tags from the note.
 
 Cards :: Shows the names of the cards which will be generated for the selected note type. Tapping on this button will bring up a dialog which lets you preview
-the source code for the card template of the selected note type.  From here you can edit, preview, add, and delete card templates. See the https://docs.ankiweb.net/#/templates/intro?id=card-templates[cards and templates section] of the Anki Desktop manual for more information about card templates.
+the source code for the card template of the selected note type.  From here you can edit, preview, add, and delete card templates. See the https://docs.ankiweb.net/templates/intro.html#card-templates[cards and templates section] of the Anki Desktop manual for more information about card templates.
 
 Long press in a text entry field to add a cloze deletion around the selected text, or an empty cloze deletion if there is no selected text.
 
@@ -331,7 +331,7 @@ dropdown list on the top left.
 
 By default, the first column in the browser gives the text which will be shown on the question (i.e. front side) of the flashcard, and the second column shows the text from the answer (i.e. the back side) of the flashcard. 
 
-The first column can also be configured to show the https://docs.ankiweb.net/#/editing?id=customizing-fields["sort field"] for a more compact display. The second column can be configured 
+The first column can also be configured to show the https://docs.ankiweb.net/editing.html#customizing-fields["sort field"] for a more compact display. The second column can be configured 
 to show many different parameters by tapping the drop down menu in the column heading. 
 
 Note that the content of the columns is dynamically calculated as your scroll through the list of the cards.
@@ -357,7 +357,7 @@ does, allowing you to perform quite complex searches. Some examples:
  flag:1 :: show only cards marked with a red flag
 
 For a full list of the possibilities, please see the section in the
-https://docs.ankiweb.net/#/searching?id=searching[desktop manual].
+https://docs.ankiweb.net/searching.html#searching[desktop manual].
 
 Alternatively, some more commonly used filters (marked, suspended, and tagged cards) can be quickly applied without manually typing them by choosing them from the overflow menu. You can also save and recall common search queries from the menu.
 
@@ -382,7 +382,7 @@ The easiest way to create a filtered deck is by long clicking on a deck and choo
 
 Advanced users can create a filtered deck manually, by choosing "Create filtered deck" from the overflow menu in the deck list screen.
 
-For further information on filtered decks, please see the https://docs.ankiweb.net/#/filtered-decks?id=filtered-decks-amp-cramming[desktop documentation].
+For further information on filtered decks, please see the https://docs.ankiweb.net/filtered-decks.html#filtered-decks-amp-cramming[desktop documentation].
 
 [[RTL]]
 == Using Right-To-Left Languages with AnkiDroid
@@ -523,9 +523,9 @@ See the <<exporting, exporting section>> below for more detailed information on 
 == Importing Anki Files
 You can import Anki files (with .apkg file format) directly into AnkiDroid. Other file formats cannot be imported directly into AnkiDroid, however 
 flashcards from most other applications can be imported into Anki Desktop on your computer, which can then be <<AnkiDesktop,added into AnkiDroid in the usual way>>. 
-See the https://docs.ankiweb.net/#/importing?id=importing[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
+See the https://docs.ankiweb.net/importing.html#importing[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
 
-As in Anki Desktop, AnkiDroid distinguishes between https://docs.ankiweb.net/#/exporting?id=exporting[the two types of .apkg files] 
+As in Anki Desktop, AnkiDroid distinguishes between https://docs.ankiweb.net/exporting.html#exporting[the two types of .apkg files] 
 ("collection package" and "deck package") based on the filename.  Collection packages have the name "collection.colpkg", and when imported will 
 completely _replace all contents_ in AnkiDroid. Any apkg file which is _*not*_ named something that ends in ".colpkg" will be treated as a deck package, 
 which will be _merged with any existing content_ when imported into to AnkiDroid.
@@ -565,7 +565,7 @@ This is not officially supported, but `.anki2` files can manually be imported if
 [[exporting]]
 == Exporting Anki Files
 AnkiDroid can export your flashcards in the .apkg Anki file format so that you can import them into Anki Desktop, or share them with other people. 
-As in Anki Desktop, you can either export a https://docs.ankiweb.net/#/exporting?id=packaged-decks[collection package or deck package], depending 
+As in Anki Desktop, you can either export a https://docs.ankiweb.net/exporting.html#packaged-decks[collection package or deck package], depending 
 on what you are trying to achieve.
 
 There are two export options available: "include scheduling information" and "include media". Generally the default options are sufficient, 
@@ -573,7 +573,7 @@ if you choose not to include scheduling information, Anki will assume that you a
 and will remove marked and leech tags so that they will have a clean copy of it.
 
 === Exporting collection package
-When exporting for use in Anki Desktop, you generally want to https://docs.ankiweb.net/#/exporting?id=collection-colpkg[export your entire collection], including all your review history etc. 
+When exporting for use in Anki Desktop, you generally want to https://docs.ankiweb.net/exporting.html#collection-colpkg[export your entire collection], including all your review history etc. 
 
 From the main menu in the decks screen:
 
@@ -818,7 +818,7 @@ Take into account the effect of future reviews in the 'Forecast' graph. More inf
 
 ==== Workarounds
 Type answer into the card ::
-If you have set up your cards to ask you to type in the answer (as explained in https://docs.ankiweb.net/#/templates/intro?id=card-templates[this section of the desktop manual]), AnkiDroid will display a keyboard on such cards and allow you to check your answer.
+If you have set up your cards to ask you to type in the answer (as explained in https://docs.ankiweb.net/templates/intro.html#card-templates[this section of the desktop manual]), AnkiDroid will display a keyboard on such cards and allow you to check your answer.
 
 +
 --
@@ -917,13 +917,13 @@ To try it out, enter the following into a field:
 
 and preview the card.
 
-For more details, see https://docs.ankiweb.net/#/math?id=mathjax[Mathjax Support] in the Anki Manual.
+For more details, see https://docs.ankiweb.net/math.html#mathjax[Mathjax Support] in the Anki Manual.
 
 https://www.reddit.com/r/Anki/comments/ar7lxd/how_to_load_mathjax_color_extension_on_anki/egm6u5j/[Previous workarounds] are no longer necessary as of AnkiDroid 2.9.
 
 [[reverseCards]]
 === Reverse Cards
-The Anki system has https://docs.ankiweb.net/#/getting-started?id=note-types[built-in note types which allow you to review cards in both directions]. 
+The Anki system has https://docs.ankiweb.net/getting-started.html#note-types[built-in note types which allow you to review cards in both directions]. 
 When <<addingNotes, creating new material>> in AnkiDroid, you should choose one of these note types, such as "Basic (and reversed card)", 
 which will automatically generate a reverse card for you.
 
@@ -936,14 +936,14 @@ or you can change the note type for multiple cards at once using the browser in 
 To do this, follow the instructions in the <<AnkiDesktop,syncing with Anki Desktop section>>, then in Anki Desktop open the browser, 
 select the cards you want to change, then choose *Change note type* from the menu.
 
-Alternatively, if your cards are using a custom card layout which doesn't include a reverse card, you can edit the note type to include a reverse card by following the instructions in the https://docs.ankiweb.net/#/templates/generation?id=reverse-cards[reverse cards section] of the Anki Desktop user manual. While less convenient than using Anki Desktop, it is possible to edit the note type from directly within AnkiDroid as well; see the <<customizingCardLayout, custom card layout section>> for more on this.
+Alternatively, if your cards are using a custom card layout which doesn't include a reverse card, you can edit the note type to include a reverse card by following the instructions in the https://docs.ankiweb.net/templates/generation.html#reverse-cards[reverse cards section] of the Anki Desktop user manual. While less convenient than using Anki Desktop, it is possible to edit the note type from directly within AnkiDroid as well; see the <<customizingCardLayout, custom card layout section>> for more on this.
 
 [[customFonts]]
 === Custom Fonts
 
 AnkiDroid allows you to use non-system fonts on your cards. To set them up properly,
 it is strongly recommended to use the official method that is used by Anki Desktop. Please see
-https://docs.ankiweb.net/#/templates/styling?id=installing-fonts[the corresponding section in the desktop
+https://docs.ankiweb.net/templates/styling.html#installing-fonts[the corresponding section in the desktop
 manual] for more information.
 
 Alternatively, you can create a new subfolder "fonts" in the main AnkiDroid directory (i.e. the folder which contains the "backups" subfolder, specified under Settings > Advanced > AnkiDroid directory), copy a compatible font file (i.e. .ttf) there, 
@@ -969,7 +969,7 @@ it's not recommended to use the combined CJK font, rather get the individual lan
 === Custom Card Layout
 The layout of flashcards is completely customizable, although this is an advanced topic with a fairly steep learning curve, and you will probably find it a lot more convenient to do the customization with <<AnkiDesktop, Anki Desktop>>. 
 
-The https://docs.ankiweb.net/#/templates/intro?id=card-templates[card templates section] of the Anki Desktop manual has detailed instructions on how to edit note types, and most of the actions discussed there are also available from AnkiDroid by tapping "cards" at the bottom of the note editor, or choosing the "manage note types" option in the deck picker. Since detailed information on customizing card layouts is available in the Anki desktop manual, it will not be repeated here.
+The https://docs.ankiweb.net/templates/intro.html#card-templates[card templates section] of the Anki Desktop manual has detailed instructions on how to edit note types, and most of the actions discussed there are also available from AnkiDroid by tapping "cards" at the bottom of the note editor, or choosing the "manage note types" option in the deck picker. Since detailed information on customizing card layouts is available in the Anki desktop manual, it will not be repeated here.
 
 There is an https://github.com/ankidroid/Anki-Android/wiki/Advanced-formatting[advanced formatting page] on the AnkiDroid wiki with various hints on how you can get the most out of your card formatting, and we encourage you to read it, and edit it freely if you have any tips that you'd like to share with the community.
 
@@ -977,7 +977,7 @@ There is an https://github.com/ankidroid/Anki-Android/wiki/Advanced-formatting[a
 === Type in the answer feature
 
 AnkiDroid allows you to type in the correct answer and then compare it to the right answer. You have to set this up with Anki desktop, 
-as described in the https://docs.ankiweb.net/#/templates/fields?id=checking-your-answer[Anki Desktop manual].
+as described in the https://docs.ankiweb.net/templates/fields.html#checking-your-answer[Anki Desktop manual].
 
 Anki desktop replaces the “{{type:NN}}” field on
 the front of a card with an input box in the card. On AnkiDroid it is replaced with a “......” prompt instead, and a text
@@ -994,7 +994,7 @@ be shown at all.
 
 To hide the comparison (e.g. because the correct answer is shown anyway), the HTML id
 “typeans” can be used. Add “.mobile #typeans {display: none;}” to the
-https://docs.ankiweb.net/#/templates/styling?id=card-styling[card styling] using Anki Desktop.
+https://docs.ankiweb.net/templates/styling.html#card-styling[card styling] using Anki Desktop.
 
 The type answer prompt and the comparison have more classes that
 can be used to change the way they are displayed. Some of these are


### PR DESCRIPTION
Currently, all of the links to the Anki Desktop manual end up showing the site's home page due to mismatch of the addresses.

An example of the mismatch is as follows:

- Address written in AnkiDroid manual
https://docs.ankiweb.net/#/templates/intro?id=card-templates

- Current actual address
https://docs.ankiweb.net/templates/intro.html#card-templates

To fix this issue, this commit will 
- remove all `#/` from `https://docs.ankiweb.net/#/`
- replace all `?id=` with `.html#`
