### PR TITLE
docs: prepare 2.16.5 changelog

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -2,6 +2,16 @@
 :sectanchors:
 = AnkiDroid Changelog
 
+== Version 2.16.5 (20230906)
+* Fix potential crash in our crash report system. See: Murphy's Law
+* Fix incorrect default setting for analytics opt-in. Should be default off.
+** Please check your setting if you want to make sure it is off
+** Note1: our analytics is always anonymized and never shared as a first step
+** Note2: the backend has been disabled for months, so there should be no exposure
+** Still this was in error and counter to our strict opt-in ethos. We are deeply sorry. 
+* Thanks again for your patience waiting for 2.16 - we're on to 2.17 work already!
+* We are humbled by the https://opencollective.com/ankidroid[donations] 🤯
+
 == Version 2.16.4 (20230827)
 * Your dev team is still very excited to be able to release quick fixes for you again!
 * Last big stability release for 2.16 series (see below for main 2.16 info)

--- a/changelog.asc
+++ b/changelog.asc
@@ -9,6 +9,7 @@
 ** Note1: our analytics is always anonymized and never shared as a first step
 ** Note2: the backend has been disabled for months, so there should be no exposure
 ** Still this was in error and counter to our strict opt-in ethos. We are deeply sorry. 
+** We will issue a future update shortly to opt everyone out as a precaution
 * Thanks again for your patience waiting for 2.16 - we're on to 2.17 work already!
 * We are humbled by the https://opencollective.com/ankidroid[donations] 🤯
 


### PR DESCRIPTION

I really struggled with how to explain the analytics lapse

My goal was to accurately describe

- the actual change
- how we treat the data in general and currently (anonymized + currently disabled because of GA4 porting needs)
- our regret at the error vs our standards

I'm open to any changes on any of it as long as they generally satisfy the goals above and sound like a human vs some person reading or writing a fake apology from a script