### PR TITLE
fix: links to Anki Manual URLs containing `--`

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -117,7 +117,7 @@ NOTE: Under some circumstances, check database will move cards to a deck named _
 
 Check media :: Try to run this if you experience any issues with media syncing.
 
-Empty cards :: Remove any empty cards from your collection. See the https://docs.ankiweb.net/templates/generation.html#card-generation-amp-deletion[desktop documentation] for more.
+Empty cards :: Remove any empty cards from your collection. See the link:++https://docs.ankiweb.net/templates/generation.html#card-generation--deletion++[desktop documentation] for more.
 
 Restore from backup :: Allows you to restore from one of AnkiDroid's <<backups,automatic backups>>
 
@@ -248,7 +248,7 @@ If you wish to keep studying the same deck further, tap on the deck again which 
 
 [[addingNotes]]
 == Add Note Screen
-*_Note:_* _This section onwards assumes you understand what https://docs.ankiweb.net/getting-started.html#notes-amp-fields[notes, fields, card templates, and note types] are_
+*_Note:_* _This section onwards assumes you understand what link:++https://docs.ankiweb.net/getting-started.html#notes--fields++[notes, fields, card templates, and note types] are_
 
 To add a new note, tap the + button at the bottom of the deck list and choose "Add".
 ++++++++++
@@ -382,7 +382,7 @@ The easiest way to create a filtered deck is by long clicking on a deck and choo
 
 Advanced users can create a filtered deck manually, by choosing "Create filtered deck" from the overflow menu in the deck list screen.
 
-For further information on filtered decks, please see the https://docs.ankiweb.net/filtered-decks.html#filtered-decks-amp-cramming[desktop documentation].
+For further information on filtered decks, please see the link:++https://docs.ankiweb.net/filtered-decks.html#filtered-decks--cramming++[desktop documentation].
 
 [[RTL]]
 == Using Right-To-Left Languages with AnkiDroid


### PR DESCRIPTION
## Purpose / Description

Anki Desktop manual has some sections which URLs contain two consecutive hyphens (`--`), but in AnkiDroid manual, the links which should be connected to the URLs actually have different URLs, and as a result the links don't open the sections.

- Ex. 
  - Actual URL: `https://docs.ankiweb.net/templates/generation.html#card-generation`**--**`deletion` 
  https://docs.ankiweb.net/templates/generation.html#card-generation--deletion
  - Different URL: `https://docs.ankiweb.net/templates/generation.html#card-generation`**-amp-**`deletion`
  https://docs.ankiweb.net/templates/generation.html#card-generation-amp-deletion

This commit will replace the different URLs with actual ones. 

## Fixes
Fixes #116

## Approach
Simple replacement from `-amp-` to `--` would cause undesirable substitution by AsciiDoc formatting. 

- Ex. `https://docs.ankiweb.net/templates/generation.html#card-generation`**--E2%80%8B**`deletion`
https://docs.ankiweb.net/templates/generation.html#card-generation--E2%80%8Bdeletion
![image](https://github.com/ankidroid/ankidroiddocs/assets/10436072/24114b3a-6930-4a63-b805-834c093bd1b4)


To prevent it, the replaced URL will be enclosed between `link:++` and `++` 

- Ex. **link:++**`https://docs.ankiweb.net/templates/generation.html#card-generation--deletion`**++**

- Ref: AsciiDoc > Passthroughs > Inline Passthroughs > Single and double plus
https://docs.asciidoctor.org/asciidoc/latest/pass/pass-macro/#single-double-plus

## How Has This Been Tested?
Checked the preview screen of manual.asc in this branch
![image](https://github.com/ankidroid/ankidroiddocs/assets/10436072/fb8266b4-16b1-4c62-85f4-c84e43a12917)
and confirmed that the correct sections are shown by clicking the link texts.
![image](https://github.com/ankidroid/ankidroiddocs/assets/10436072/fcafbb51-d92c-41fe-b2da-e6a513080857)

