### PR TITLE
document removal of reminders

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -1014,15 +1014,6 @@ containing the comparison on the answer side. This class can be used
 to show the type prompt or to hide the typing comparison in
 this case.
 
-[[reminders]]
-=== Reminders
-AnkiDroid can remind you to devote some time to reviewing cards every day at a specific time via Android's notification framework.
-You can configure reminders for each options group independently.
-To configure a notification go to Deck options > Reminders, then tick the checkbox and select the time you want to be notified at.
-To stop receiving notifications go to Deck options > Reminders and unmark the checkbox.
-
-Notifications only work for top level decks. Please let us know if you want us to add notifications for subdecks too.
-
 [[setlanguagehint]]
 === Automatic Language Selection
 AnkiDroid has an in Automatic Language Selection feature in the Note Editor starting with AnkiDroid 2.13. This feature allows you to define a default language to be used in your keyboard for a field in a note type.


### PR DESCRIPTION
This commit will remove the section of reminders (which existed in deck options of legacy backend) from "Advanced Features" chapter.