### PR TITLE
feat: add AnkiDroid-specific page for AnkiWeb account removal

### DIFF
--- a/remove-account.asc
+++ b/remove-account.asc
@@ -1,0 +1,33 @@
+:docinfo1:
+:experimental:
+
+= Remove Account
+:sectanchors:
+
+== AnkiWeb Account Deletion for AnkiDroid
+
+The https://play.google.com/store/apps/details?id=com.ichi2.anki[AnkiDroid Flashcards] Android application,
+developed by the https://play.google.com/store/apps/developer?id=AnkiDroid+Open+Source+Team[AnkiDroid Open Source Team],
+has features that let you keep your AnkiDroid flashcard collection in sync with the https://ankiweb.net/about[AnkiWeb] online service.
+
+If you have created an account with AnkiWeb to use these features, either from within AnkiDroid or directly on AnkiWeb, you
+may request deletion of that account at any time, in accordance with AnkiWeb's https://ankiweb.net/account/privacy[data handling policies].
+
+
+=== AnkiWeb Direct Removal
+
+If you no longer have AnkiDroid installed, or you would like to delete the account directly now on the web:
+====
+Follow the process on AnkiWeb's https://ankiweb.net/account/remove-account[account removal page].
+====
+
+=== Account Removal from within AnkiDroid
+
+If you still have AnkiDroid installed, you may request AnkiWeb account deletion from within the app:
+====
+1. Enter "Settings"
+2. Enter "Sync"
+3. Select "AnkiWeb account"
+4. Tap the "Remove account" button
+5. Follow the instructions on the Remove Account screen
+====


### PR DESCRIPTION
Should be sufficient to satisfy Google Play Store review of account removal requirements, without transitively "infecting" Anki/AnkiWeb with AnkiDroid-specific requirements (something I would like to avoid as it doesn't put the work in the right spot, IMHO)

<img width="846" alt="image" src="https://github.com/ankidroid/ankidroiddocs/assets/782704/f70b1f4f-303d-49df-be4c-6a6c99d21ca3">
