### PR TITLE
release: 2.18.1 changelog

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -12,7 +12,7 @@
 * Fix crash in template previewer
 * Fix deck handling note editor
 * Fix reviewer regressions in javascript and visual performance
-* Fix android-app:// links in previewer
+* Fix `android-app://` and `intent://` links in previewer
 * Fix tag checkbox colors
 * Improve optimizing presets message
 * Fix preferences message display overflow

--- a/changelog.asc
+++ b/changelog.asc
@@ -2,6 +2,21 @@
 :sectanchors:
 = AnkiDroid Changelog
 
+== Version 2.18.1 (20240523)
+* Minor fixes to polish up the 2.18.0 release, main notes below 👇
+* AnkiDroid is participating in Google Summer of Code again!
+* Your https://opencollective.com/ankidroid[donations] inspire a new generation of open source contributors 💓
+* Fix crash in TagsDialog (this is for you, Anking users!)
+* Fresh translations from our community of https://crowdin.com/project/ankidroid[translators] (thank you!)
+* Fix language handling for regional variants
+* Fix crash in template previewer
+* Fix deck handling note editor
+* Fix reviewer regressions in javascript and visual performance
+* Fix android-app:// links in previewer
+* Fix tag checkbox colors
+* Improve optimizing presets message
+* Fix preferences message display overflow
+
 == Version 2.18.0 (20240512)
 * Switching to more direct use of Anki blocked 2.17 for a year, but with 2.18 we are back on a more rapid release cadence. Enjoy!
 * We really appreciate the https://opencollective.com/ankidroid[donations], they paid for these features 🤝


### PR DESCRIPTION
Here are the picks:

https://github.com/ankidroid/Anki-Android/issues?q=label%3A%22Cherry+Picked+to+Stable+Branch%22+milestone%3A%222.18.1+release%22

Looks like this (I verified the links were correct)

<img width="689" alt="image" src="https://github.com/ankidroid/ankidroiddocs/assets/782704/d68476c6-79d2-4716-a866-ed1cf44f43bf">
