### PR TITLE
docs: changelog for version 2.19.5

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -174,6 +174,10 @@ In 2020, implementing Anki's latest scheduling improvements would have taken yea
 * https://crowdin.com/project/ankidroid[New community-provided language translations]
 * https://github.com/ankidroid/Anki-Android/milestone/64?closed=1[Full changelog]
 
+== Version 2.19.5 (20250711)
+* Security patch for Ankidroid API to correctly enforce permissions
+  backported to older versions that still support Android 6 and below
+
 == Version 2.19.4 (20250110)
 * Restore the 2.19 series to the Play Store for Android versions 6 and older
   We do our best to make sure old devices are not forced into obsolescence


### PR DESCRIPTION
This APK was manually / locally built to generate a set of APKs I could include in the 2.21.0 release (via manually uploading them / adding them to the release as fallback APKs with lower version codes for lower Android API devices)

This was done as I launched that 2.21.0 release, so the changelog was also locally produced - just uploading it now for posterity / completeness