### PR TITLE
Update changelog.asc to list Anki 25.07.4

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -9,7 +9,7 @@ Another release containing all of Anki's new improvements (and a few of our own)
 Your https://opencollective.com/ankidroid/contribute[donations] helped us get these changes out so quickly! 🤜🤛
 
 * *Features*
-** Includes https://apps.ankiweb.net/[Anki 25.07.3], with https://github.com/open-spaced-repetition/fsrs4anki[FSRS 6.0]
+** Includes https://apps.ankiweb.net/[Anki 25.07.4], with https://github.com/open-spaced-repetition/fsrs4anki[FSRS 6.0]
 ** Card Browser - Grade Now: Inform Anki's scheduler that you forgot a card at any time
 ** FSRS 6: Updated FSRS scheduler. 
 *** For optimal scheduling: update all your Anki clients, sync, then re-optimize FSRS


### PR DESCRIPTION
Added in https://github.com/ankidroid/Anki-Android/commit/bacffdbe858ee7c8835c27745a3a174f4a52825f which appears to have made it into 2.22.0