### PR TITLE
test(ci): restrict github token to minimal permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: "Publish docs.ankidroid.org"

--- a/.github/workflows/render_docs.yml
+++ b/.github/workflows/render_docs.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   render_docs:
     name: 'Render Docs'


### PR DESCRIPTION
I don't believe any of our workflows need anything other than contents: read

Should fix:

- https://github.com/ankidroid/ankidroiddocs/security/code-scanning/1
- https://github.com/ankidroid/ankidroiddocs/security/code-scanning/2