### PR TITLE
Add documentation for Forget Cards options

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -358,11 +358,22 @@ perform the following actions:
 Mark / unmark note :: Add / remove the "marked" tag from the note. Cards with a marked note are highlighted in purple.
 Flag card :: Change or remove the color coded "flag" on the card. Cards with a flag are highlighted in the flags color.
 Suspend / unsuspend card :: Suspended cards are highlighted in yellow, and are not shown during review.
-Forget cards :: Reset selected cards back to the "new" state, removing their scheduling information. This action presents two options:
+Reset :: Reset selected cards back to the "new" state, removing their scheduling information.
 
-- **Restore original position where possible:** When enabled, this option attempts to restore the card to its original position in the new card queue. This is useful when you want to maintain the original order of cards as they were initially added or imported.
-- **Reset repetition and lapse counts:** When enabled, this option resets the review and failure counters for the card back to zero. Note that this does not remove the review history that is shown in the card info screen, but it does reset the statistical counters used for scheduling.
+=== Reset options
 
+==== Restore original position where possible
+- Returns the card to its original position in the New card queue (if known)
+- Does not affect intervals, learning steps, or statistics
+
+==== Reset repetition and lapse counts
+- Resets the card's repetition and lapse counters to zero
+- Does **not** affect scheduling or intervals
+- Review history is preserved
+
+Note: The card's interval is reset regardless of whether this option is enabled or disabled. Checking or unchecking Reset repetition and lapse counts does not change scheduling behavior—only the displayed statistics.
+
+Reschedule :: Allows you to reschedule selected cards as review cards on a given date. This is useful if you have imported already-learnt material and want to start it off with higher initial intervals.
 Delete note :: Delete the note of the currently selected card, and all cards belonging to that note. 
 This action cannot be undone without <<backups,restoring from backup>>.
 Preview :: Render the currently selected card so that you can see what it looks like in the study screen.

--- a/manual.asc
+++ b/manual.asc
@@ -358,6 +358,11 @@ perform the following actions:
 Mark / unmark note :: Add / remove the "marked" tag from the note. Cards with a marked note are highlighted in purple.
 Flag card :: Change or remove the color coded "flag" on the card. Cards with a flag are highlighted in the flags color.
 Suspend / unsuspend card :: Suspended cards are highlighted in yellow, and are not shown during review.
+Forget cards :: Reset selected cards back to the "new" state, removing their scheduling information. This action presents two options:
+
+- **Restore original position where possible:** When enabled, this option attempts to restore the card to its original position in the new card queue. This is useful when you want to maintain the original order of cards as they were initially added or imported.
+- **Reset repetition and lapse counts:** When enabled, this option resets the review and failure counters for the card back to zero. Note that this does not remove the review history that is shown in the card info screen, but it does reset the statistical counters used for scheduling.
+
 Delete note :: Delete the note of the currently selected card, and all cards belonging to that note. 
 This action cannot be undone without <<backups,restoring from backup>>.
 Preview :: Render the currently selected card so that you can see what it looks like in the study screen.


### PR DESCRIPTION
Fixes #136

This PR adds documentation for the "Forget Cards" functionality in the browser section, specifically explaining the two new options:
- Restore original position where possible" - restores cards to their original position in the new card queue
- Reset repetition and lapse counts" - resets review and failure counters to zero while preserving review history
The documentation is added to the browser section where other card actions are documented, following the same format and style.
