### PR TITLE
Fix broken link to Anki importing documentation

### DIFF
--- a/manual.asc
+++ b/manual.asc
@@ -553,7 +553,7 @@ See the <<exporting, exporting section>> below for more detailed information on 
 == Importing Anki Files
 You can import Anki files (with .apkg file format) directly into AnkiDroid. Other file formats cannot be imported directly into AnkiDroid, however 
 flashcards from most other applications can be imported into Anki Desktop on your computer, which can then be <<AnkiDesktop,added into AnkiDroid in the usual way>>. 
-See the https://docs.ankiweb.net/importing.html#importing[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
+See the https://docs.ankiweb.net/importing/intro.html[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
 
 As in Anki Desktop, AnkiDroid distinguishes between https://docs.ankiweb.net/exporting.html#exporting[the two types of .apkg files] 
 ("collection package" and "deck package") based on the filename.  Collection packages have the name "collection.colpkg", and when imported will 


### PR DESCRIPTION

<img width="1907" height="943" alt="Screenshot 2026-01-10 165608" src="https://github.com/user-attachments/assets/88624a2a-e085-49a4-a2a6-7ac2b8614fd5" />
Description
This PR fixes a broken link in the AnkiDroid documentation that was returning a 404 error.
 Changes Made
- Updated the broken link in `manual.asc` (line 556)
- Changed from: `https://docs.ankiweb.net/importing.html#importing`
- Changed to: `https://docs.ankiweb.net/importing/intro.html`

## Testing
- Verified the new link works correctly and points to the Anki importing documentation
- Confirmed the old broken link no longer exists in the codebase

Fixes #176
