### PR TITLE
solved grammatical errors in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,6 @@ On Mac we recommend using [Homebrew](https://brew.sh) package manager to install
 
 The preferred method of contributing to the documentation is to fork the `ankidroiddocs` project on github, and send a pull request with your additions in the usual way. However, if you don't know how to use github, you can simply download the "manual.asc" file and send it to a project member or the Google Group.
 
-To create a translation of the manual, please make a copy of "manual.asc" and add "-LANUGAGE\_CODE" ([list of ISO\_639-1 language codes](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)). For example for Italian submit a translated file called "manual-it.asc" based on the original source file.
+To create a translation of the manual, please make a copy of "manual.asc" and add "-LANGUAGE\_CODE" ([list of ISO\_639-1 language codes](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)). For example for Italian submit a translated file called "manual-it.asc" based on the original source file.
 
 Translations should be periodically updated to reflect any changes in the original manual. Details of all changes can be found in the [list of commits](https://github.com/ankidroid/ankidroiddocs/commits/main/).

--- a/manual.asc
+++ b/manual.asc
@@ -10,7 +10,7 @@
 Thank you for using AnkiDroid, the Android client for the popular 
 http://ankisrs.net/[Anki] spaced repetition system. 
 
-Anki is spaced repetition technique which is simple but highly effective. It helps you memorize things by automatically repeating them across increasing intervals based on your responses with no need for you to keep track of what to study or when to study it. You create notes (or download shared decks) with content you need to memorize, and the scheduler will make sure you see the content when you need to.
+Anki is a spaced repetition technique which is simple but highly effective. It helps you memorize things by automatically repeating them across increasing intervals based on your responses with no need for you to keep track of what to study or when to study it. You create notes (or download shared decks) with content you need to memorize, and the scheduler will make sure you see the content when you need to.
 
 AnkiDroid is intended to be used in conjunction with Anki on your computer. While it is possible to function without it, 
 some tasks are either only possible with, or a lot more efficient with Anki Desktop. Furthermore, it is *strongly recommended* to at least read https://docs.ankiweb.net/getting-started.html#key-concepts["Key Concepts"] section of the main Anki manual to understand the terminology used here.
@@ -275,7 +275,7 @@ The following controls are available in the add note screen:
 
 Type :: Allows you to select the type of note you'd like to add. 
 For most purposes the "Basic" note type is sufficient, but for example if you would like an extra card generated which is the reverse of the main card  
-(i.e. shows the "Back" field on the front of the card), you could chose the "Basic (and reversed card)" note type.
+(i.e. shows the "Back" field on the front of the card), you could choose the "Basic (and reversed card)" note type.
 
 Deck :: Allows you to change the deck the generated card/cards will be added to.
 
@@ -558,7 +558,7 @@ See the https://docs.ankiweb.net/importing/intro.html[importing section of the A
 As in Anki Desktop, AnkiDroid distinguishes between https://docs.ankiweb.net/exporting.html#exporting[the two types of .apkg files] 
 ("collection package" and "deck package") based on the filename.  Collection packages have the name "collection.colpkg", and when imported will 
 completely _replace all contents_ in AnkiDroid. Any apkg file which is _*not*_ named something that ends in ".colpkg" will be treated as a deck package, 
-which will be _merged with any existing content_ when imported into to AnkiDroid.
+which will be _merged with any existing content_ when imported into AnkiDroid.
 
 You can import .apkg Anki collection files into AnkiDroid either by opening them using the standard Android system, or by manually 
 importing them from within AnkiDroid:

--- a/manual.asc
+++ b/manual.asc
@@ -553,7 +553,7 @@ See the <<exporting, exporting section>> below for more detailed information on 
 == Importing Anki Files
 You can import Anki files (with .apkg file format) directly into AnkiDroid. Other file formats cannot be imported directly into AnkiDroid, however 
 flashcards from most other applications can be imported into Anki Desktop on your computer, which can then be <<AnkiDesktop,added into AnkiDroid in the usual way>>. 
-See the https://docs.ankiweb.net/importing.html#importing[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
+See the https://docs.ankiweb.net/importing/intro.html[importing section of the Anki Desktop manual] for help on importing into Anki Desktop.
 
 As in Anki Desktop, AnkiDroid distinguishes between https://docs.ankiweb.net/exporting.html#exporting[the two types of .apkg files] 
 ("collection package" and "deck package") based on the filename.  Collection packages have the name "collection.colpkg", and when imported will 


### PR DESCRIPTION
## Errors Found
 ### README.md - 
**Line 35**: LANUGAGE_CODE should be LANGUAGE_CODE (typo)
 
### manual.asc - 
**Line 14**: Anki is spaced repetition technique should be Anki is a spaced repetition technique (missing article) - **Line 278**: you could chose should be you could choose (incorrect verb tense) 
**Line 561**: imported into to AnkiDroid should be imported into AnkiDroid (duplicate word)