### PR TITLE
release 2.24.1 changelog (and 2.16, 2.19 backports)

### DIFF
--- a/changelog.asc
+++ b/changelog.asc
@@ -2,6 +2,53 @@
 :sectanchors:
 = AnkiDroid Changelog
 
+== Version 2.24.1 (20260831)
+
+Urgent update to our 2.24.0 release: security updates, and temporarily removing donation links to
+comply with Play Store policies (more below).
+
+A special thank you to the following people for reporting the security issues fixed in this release:
+
+* https://github.com/Kwstubbs[Kevin Stubbings] of the GitHub Security Lab (GHSL-2026-083, GHSL-2026-084, GHSL-2026-085)
+* https://github.com/kah-ja[Jan Kahmen] for (GHSA-qjjx-px4w-4986)
+* https://github.com/criticalAY[Ashish Yadav] (GHSA-cr2g-gf75-cm6r)
+
+*Removal of donation links*: Please see https://github.com/ankidroid/Anki-Android/issues/21656[GitHub Issue 21656] for why this has happened and how
+to help us with this.
+
+Please see the xref:#_version_2_24_0_20260502[2.24.0 changelog] below for the main 2.24 features announcement 👇
+
+* Security
+** Reviewer: cards can no longer open dangerous links [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+** Reviewer: cards require permission to launch apps [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** JavaScript API: blocked calls which could read and modify cards (other than the currently selected card) [GHSL-2026-084, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** Reviewer: fix path traversal when loading media [GHSL-2026-083, GHSA-qjjx-px4w-4986]
+** Import: sanitize filenames to block path traversal [GHSA-q29p-h3pp-mh3v]
+** Note Editor: reject untrusted files from the image picker [GHSA-cr2g-gf75-cm6r]
+* Improvements
+** Privacy: removed a log entry which could hint at your timezone
+** Card Browser: better 'invalid search' messages
+** Google Play: 'Donate' links removed to comply with Play policies
+* Fixes
+** Deck Picker & Card Browser: Fix memory leaks
+** Fix crash when sharing an image to the Note Editor
+** Fix crash when exporting a large number of notes
+** Fix 'Auto Advance' not following the review queue
+** Improve error names in error messages
+** Whiteboard: fix flickering [Samsung/OnePlus]
+** Whiteboard: fix crash on rotation when 'type in the answer' is open
+** Note Editor: fix 'MathJax block' syntax
+** Note Types: only enable 'Save' when there are unsaved changes
+** Sync: fix conflict dialog only showing its title [Samsung-only]
+** Export: sharing text is now a text/plain file
+** Settings: fix crash when dragging reviewer actions and switching screens
+** Settings: include 'Themes' in search results
+** Reviewer: fix snackbar position when answer buttons are hidden
+
+Full list of https://github.com/ankidroid/Anki-Android/milestone/78?closed=1[2.24.1 fixes]
+
 == Version 2.24.0 (20260502)
 
 It's new version time! AnkiDroid 2.24.0 is here! 🥳
@@ -477,6 +524,32 @@ In 2020, implementing Anki's latest scheduling improvements would have taken yea
 * https://crowdin.com/project/ankidroid[New community-provided language translations]
 * https://github.com/ankidroid/Anki-Android/milestone/64?closed=1[Full changelog]
 
+== Version 2.19.6 (20260831)
+
+Urgent update to our 2.19.5 release: security updates, and temporarily removing donation links to
+comply with Play Store policies (more below).
+
+A special thank you to the following people for reporting the security issues fixed in this release:
+
+* https://github.com/Kwstubbs[Kevin Stubbings] of the GitHub Security Lab (GHSL-2026-084, GHSL-2026-085)
+* https://github.com/kah-ja[Jan Kahmen] for (GHSA-qjjx-px4w-4986)
+
+*Removal of donation links*: Please see https://github.com/ankidroid/Anki-Android/issues/21656[GitHub Issue 21656] for why this has happened and how
+to help us with this.
+
+Please see the xref:#_version_2_19_1_20241031[2.19.1 changelog] below for the main 2.19 features announcement 👇
+
+* Security
+** Reviewer: cards can no longer open dangerous links [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+** Reviewer: cards require permission to launch apps [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** JavaScript API: blocked calls which could read and modify cards (other than the currently selected card) [GHSL-2026-084, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** Reviewer: fix path traversal when loading media [GHSA-qjjx-px4w-4986]
+** Import: sanitize filenames to block path traversal [GHSA-q29p-h3pp-mh3v]
+* Improvements
+** Google Play: 'Donate' links removed to comply with Play policies
+
 == Version 2.19.5 (20250711)
 * Security patch for Ankidroid API to correctly enforce permissions
   backported to older versions that still support Android 6 and below
@@ -750,6 +823,32 @@ In 2020, implementing Anki's latest scheduling improvements would have taken yea
 ** link:++https://github.com/ankidroid/Anki-Android/compare/v2.16.5...main++[958 changes from 26 contributors since 2.16]
 ** https://opencollective.com/ankidroid[Thank you to our 3696 backers]
 ** https://crowdin.com/project/ankidroid[1972 Translators]
+
+== Version 2.16.6 (20260831)
+
+Urgent update to our 2.16.5 release: security updates, and temporarily removing donation links to
+comply with Play Store policies (more below).
+
+A special thank you to the following people for reporting the security issues fixed in this release:
+
+* https://github.com/Kwstubbs[Kevin Stubbings] of the GitHub Security Lab (GHSL-2026-084, GHSL-2026-085)
+* https://github.com/kah-ja[Jan Kahmen] for (GHSA-qjjx-px4w-4986)
+
+*Removal of donation links*: Please see https://github.com/ankidroid/Anki-Android/issues/21656[GitHub Issue 21656] for why this has happened and how
+to help us with this.
+
+Please see the xref:#_version_2_16_2_20230726[2.16.2 changelog] below for the main 2.16 features announcement 👇
+
+* Security
+** Reviewer: cards can no longer open dangerous links [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+** Reviewer: cards require permission to launch apps [GHSL-2026-085, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** JavaScript API: blocked calls which could read and modify cards (other than the currently selected card) [GHSL-2026-084, GHSA-54q9-5c5p-9rxg]
+*** May be unblocked in advanced settings, if all your cards are trustworthy.
+** Reviewer: fix path traversal when loading media [GHSA-qjjx-px4w-4986]
+** Import: sanitize filenames to block path traversal [GHSA-q29p-h3pp-mh3v]
+* Improvements
+** Google Play: 'Donate' links removed to comply with Play policies
 
 == Version 2.16.5 (20230906)
 * Fix potential crash in our crash report system. See: Murphy's Law


### PR DESCRIPTION
## Summary
- Adds `changelog.asc` headings for public releases dated 20260831: **2.24.1**, plus backports **2.19.6** and **2.16.6** (so `tools/release.sh` can find `Version $VERSION`).
- 2.24.1 includes the full notes (security, Play donation-link removal, bugfixes). 2.19.6 / 2.16.6 are security + donation-link removal only (no 2.24.1 bugfixes; no Ashish/criticalAY image-picker fix).

## Test plan
- [x] Confirm headings: `== Version 2.24.1 (20260831)`, `== Version 2.19.6 (20260831)`, `== Version 2.16.6 (20260831)`
- [x] Confirm 2.24.1 xref to 2.24.0 (`#_version_2_24_0_20260502`) resolves
- [x] Confirm 2.19.6 and 2.16.6 only include security fixes and donation-link removal, with no 2.24.1 bugfixes or the Note Editor image-picker fix